### PR TITLE
Flatpak: remove gtk and graphene moduels

### DIFF
--- a/build-aux/flatpak/org.sadiqpk.notes.flatpak.json
+++ b/build-aux/flatpak/org.sadiqpk.notes.flatpak.json
@@ -91,42 +91,6 @@
             ]
         },
         {
-            "name" : "graphene",
-            "buildsystem": "meson",
-            "builddir": true,
-            "config-opts" : [
-                "--libdir=lib",
-                "-Dintrospection=false",
-                "-Dtests=false",
-                "-Dbenchmarks=false"
-            ],
-            "sources" : [
-                {
-                    "type" : "git",
-                    "url" : "https://github.com/ebassi/graphene.git",
-                    "tag": "1.8.2"
-                }
-            ]
-        },
-        {
-            "name" : "gtk_",
-            "buildsystem": "meson",
-            "builddir": true,
-            "config-opts" : [
-                "--libdir=lib",
-                "-Dintrospection=false",
-                "-Ddemos=true",
-                "-Dbuild-examples=false",
-                "-Dbuild-tests=false"
-            ],
-            "sources" : [
-                {
-                    "type" : "git",
-                    "url" : "https://gitlab.gnome.org/GNOME/gtk.git"
-                }
-            ]
-        },
-        {
             "name": "gnome-notes",
             "buildsystem": "meson",
             "builddir": true,


### PR DESCRIPTION
Gtk4 is included in the master runtime now and thus we don't need
to build it anymore.